### PR TITLE
Implement AJAX-friendly login and signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# homecampus-python-3
+# HomeCampus Python
+
+This project contains a small Flask application used for serving math content. It now includes very basic user authentication using **Flask-Login** and **SQLAlchemy**.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the `DATABASE_URL` environment variable if you want to use a database other than the default SQLite database `app.db`. This is useful when deploying to Google Cloud (e.g., Cloud SQL).
+3. Initialize the database and run the server:
+   ```bash
+   python app2.py
+   ```
+
+The app will create the database tables on first run. You can then register new users at `/Register` and sign in at `/LoginPage`.
+Both `/SignIn` and `/Register` also accept AJAX POST requests when the query
+parameter `async` is present. These endpoints return JSON indicating success and
+the redirect URL used by the embedded JavaScript forms.

--- a/app2.py
+++ b/app2.py
@@ -1,6 +1,19 @@
 from flask import Flask, render_template, request, redirect, url_for, flash
-from flask_login import LoginManager, login_user, logout_user, login_required, current_user
-from models import get_user_by_username, get_user_by_id
+from flask_login import (
+    LoginManager,
+    login_user,
+    logout_user,
+    login_required,
+    current_user,
+)
+from config import Config
+from models import (
+    db,
+    User,
+    get_user_by_username,
+    get_user_by_id,
+    create_user,
+)
 from flask import abort
 import Grade7PageConfig 
 from LearnMappings import Grade3Mapper as mapper
@@ -8,8 +21,10 @@ import traceback
 from flask import send_file
 from flask import send_from_directory, abort
 import os
+
 app = Flask(__name__)
-app.secret_key = 'your-secret-key'
+app.config.from_object(Config)
+db.init_app(app)
 
 login_manager = LoginManager()
 login_manager.init_app(app)
@@ -26,7 +41,13 @@ def index():
     return render_template('HomePage.html')
 @app.context_processor
 def inject_user():
-    return dict(current_user=current_user)
+    """Make common helpers available in all templates."""
+    return dict(
+        current_user=current_user,
+        login_url=url_for('login'),
+        logout_url=url_for('logout'),
+        current_url=request.url,
+    )
 
 @app.route('/LoginPage', methods=['GET', 'POST'])
 def login():
@@ -36,9 +57,70 @@ def login():
         user = get_user_by_username(username)
         if user and user.password == password:
             login_user(user)
+            if 'async' in request.args:
+                continue_url = request.args.get('continue') or url_for('index')
+                return {'success': True, 'continue_url': continue_url}
             return redirect(url_for('index'))
+        if 'async' in request.args:
+            return {'success': False, 'error': 'Invalid credentials'}
         flash('Invalid credentials')
     return render_template('LoginPage.html')
+
+
+@app.route('/SignIn', methods=['GET', 'POST'])
+def signin():
+    """AJAX-friendly sign-in endpoint."""
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        user = get_user_by_username(username)
+        if user and user.password == password:
+            login_user(user)
+            if 'async' in request.args:
+                continue_url = request.args.get('continue') or url_for('index')
+                return {'success': True, 'continue_url': continue_url}
+            return redirect(url_for('index'))
+        # invalid credentials
+        if 'async' in request.args:
+            return {'success': False, 'error': 'Invalid credentials'}
+        flash('Invalid credentials')
+    return render_template('LoginPage.html')
+
+
+@app.route('/Register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form.get('email')
+        password = request.form.get('parent_password')
+        if not username or not password:
+            if 'async' in request.args:
+                return {'success': False, 'error': 'Email and password are required.'}
+            flash('Email and password are required.')
+            return render_template('RegisterPage.html')
+
+        if get_user_by_username(username):
+            if 'async' in request.args:
+                return {'success': False, 'error': 'User already exists.'}
+            flash('User already exists.')
+            return render_template('RegisterPage.html')
+
+        user = create_user(username, password)
+        if 'async' in request.args:
+            login_user(user)
+            continue_url = request.args.get('continue') or url_for('index')
+            return {'success': True, 'continue_url': continue_url}
+
+        flash('Registration successful. Please log in.')
+        return redirect(url_for('login'))
+
+    return render_template('RegisterPage.html')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
 
 
 
@@ -500,4 +582,6 @@ def learn_page():
     return render_template('LearnPage.html', section='content')
 
 if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
     app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,33 +1,40 @@
 from flask_sqlalchemy import SQLAlchemy
-
-db = SQLAlchemy()
 from flask_login import UserMixin
 
-# Dummy in-memory user store (replace with DB later)
-users = {
-    'admin': {'id': 1, 'username': 'admin', 'password': 'admin123'},
-}
+db = SQLAlchemy()
 
-class User(UserMixin):
-    def __init__(self, id, username, password):
-        self.id = id
-        self.username = username
-        self.password = password
+
+class User(db.Model, UserMixin):
+    """Simple user model for authentication."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password = db.Column(db.String(150), nullable=False)
 
     def get_id(self):
         return str(self.id)
 
+
 def get_user_by_username(username):
-    user_data = users.get(username)
-    if user_data:
-        return User(**user_data)
-    return None
+    """Return a user by username."""
+    if not username:
+        return None
+    return User.query.filter_by(username=username).first()
+
 
 def get_user_by_id(user_id):
-    for user_data in users.values():
-        if str(user_data['id']) == str(user_id):
-            return User(**user_data)
-    return None
+    """Return a user by id."""
+    if not user_id:
+        return None
+    return User.query.get(int(user_id))
+
+
+def create_user(username, password):
+    """Create and return a new user."""
+    user = User(username=username, password=password)
+    db.session.add(user)
+    db.session.commit()
+    return user
 
 class HCSubscription(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
## Summary
- provide `login_url`, `logout_url` and `current_url` to templates
- add `/SignIn` endpoint for JS-based logins
- extend `/Register` to return JSON on async calls
- document async auth behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app2.py > /tmp/server.log 2>&1 & sleep 5; pkill -f app2.py`

------
https://chatgpt.com/codex/tasks/task_e_685911d6286883338732a01433def5a5